### PR TITLE
Namespace the topic config value.

### DIFF
--- a/fedmsg.d/config.py
+++ b/fedmsg.d/config.py
@@ -1,7 +1,7 @@
 config = dict(
     fedmsg_atomic_composer=True,
     config_key='fedmsg_atomic_composer',
-    topic=[
+    fedmsg_atomic_topic=[
         'org.fedoraproject.prod.bodhi.updates.fedora.sync',
         'org.fedoraproject.prod.compose.branched.rsync.complete',
         'org.fedoraproject.prod.compose.rawhide.rsync.complete',

--- a/fedmsg_atomic_composer/consumer.py
+++ b/fedmsg_atomic_composer/consumer.py
@@ -29,6 +29,8 @@ class AtomicConsumer(fedmsg.consumers.FedmsgConsumer):
         for key, item in hub.config.items():
             setattr(self, key, item)
 
+        self.topic = self.fedmsg_atomic_topic
+
         super(AtomicConsumer, self).__init__(hub, *args, **kw)
 
     def consume(self, msg):


### PR DESCRIPTION
Turns out that the `topic` config value is used elsewhere and by
having it in fedmsg.d/ it caused fedmsg-tail to break.
