### PR TITLE
Gracefully fail at startup if fedmsg_atomic_topic is not set.

### DIFF
--- a/fedmsg_atomic_composer/consumer.py
+++ b/fedmsg_atomic_composer/consumer.py
@@ -29,9 +29,12 @@ class AtomicConsumer(fedmsg.consumers.FedmsgConsumer):
         for key, item in hub.config.items():
             setattr(self, key, item)
 
-        self.topic = self.fedmsg_atomic_topic
+        self.topic = getattr(self, 'fedmsg_atomic_topic', None)
 
         super(AtomicConsumer, self).__init__(hub, *args, **kw)
+
+        if not self.topic:
+            self.log.warn("No 'fedmsg_atomic_topic' set.")
 
     def consume(self, msg):
         """Called with each incoming fedmsg.


### PR DESCRIPTION
I get emails all the time for this that look like:

```python
Message
-------
[2015-09-17 15:53:16][moksha.hub   ERROR]
Failed to init <class 'fedmsg_atomic_composer.consumer.AtomicConsumer'> consumer.


Process Details
---------------
host:     bodhi-backend01.phx2.fedoraproject.org
PID:      10520
name:     fedmsg-hub
command:  /usr/bin/python /usr/bin/fedmsg-hub

Callstack that lead to the logging statement
--------------------------------------------
  File "/usr/bin/fedmsg-hub", line 9 in <module>
    load_entry_point('fedmsg==0.15.0', 'console_scripts', 'fedmsg-hub')()
  File "/usr/lib/python2.7/site-packages/fedmsg/commands/hub.py", line 92 in hub
    command.execute()
  File "/usr/lib/python2.7/site-packages/fedmsg/commands/__init__.py", line 104 in execute
    return self.run()
  File "/usr/lib/python2.7/site-packages/fedmsg/commands/hub.py", line 86 in run
    framework=False,
  File "/usr/lib/python2.7/site-packages/moksha/hub/__init__.py", line 81 in main
    hub = CentralMokshaHub(config, consumers=consumers, producers=producers)
  File "/usr/lib/python2.7/site-packages/moksha/hub/hub.py", line 234 in __init__
    self.__init_consumers()
  File "/usr/lib/python2.7/site-packages/moksha/hub/hub.py", line 382 in __init_consumers
    log.exception("Failed to init %r consumer." % c_class)
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/moksha/hub/hub.py", line 366, in __init_consumers
    c = c_class(self)
  File "/usr/lib/python2.7/site-packages/fedmsg_atomic_composer/consumer.py", line 32, in __init__
    self.topic = self.fedmsg_atomic_topic
AttributeError: 'AtomicConsumer' object has no attribute 'fedmsg_atomic_topic'
```