### PR TITLE
repo.mako: set enabled to 1

### DIFF
--- a/fedmsg_atomic_composer/templates/repo.mako
+++ b/fedmsg_atomic_composer/templates/repo.mako
@@ -17,7 +17,7 @@ baseurl=${url}
 % endif
 gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-${version}-${arch}
-enabled=0
+enabled=1
 metadata_expire=0
 skip_if_unavailable=False
 %endfor


### PR DESCRIPTION
Since we're already skipping over the repos that rpm-ostree doesn't
need, it's safe to do this. It also allows us to work around

https://github.com/rpm-software-management/libdnf/issues/250

and get bodhi working again:

https://pagure.io/releng/issue/6602