### PR TITLE
mock config: explicitly install ostree

### DIFF
--- a/fedmsg_atomic_composer/templates/mock.mako
+++ b/fedmsg_atomic_composer/templates/mock.mako
@@ -2,7 +2,7 @@ config_opts['root'] = '${mock}'
 config_opts['target_arch'] = '${arch}'
 config_opts['dist'] = '${git_branch}'  # only useful for --resultdir variable subst
 config_opts['releasever'] = '${version}'
-config_opts['chroot_setup_cmd'] = 'install yum rpm-ostree'
+config_opts['chroot_setup_cmd'] = 'install yum rpm-ostree ostree'
 config_opts['extra_chroot_dirs'] = ['/run/lock']
 config_opts['plugin_conf']['bind_mount_enable'] = True
 config_opts['plugin_conf']['bind_mount_opts']['dirs'].append(('${work_dir}', '${work_dir}'))


### PR DESCRIPTION
rpm-ostree now doesn't depend on ostree directly, but ostree-libs so
/usr/bin/ostree doesn't get pulled in by default.