### PR TITLE
templates: Ensure ostree is installed

### DIFF
--- a/fedmsg_atomic_composer/templates/mock.mako
+++ b/fedmsg_atomic_composer/templates/mock.mako
@@ -2,7 +2,7 @@ config_opts['root'] = '${mock}'
 config_opts['target_arch'] = '${arch}'
 config_opts['dist'] = '${git_branch}'  # only useful for --resultdir variable subst
 config_opts['releasever'] = '${version}'
-config_opts['chroot_setup_cmd'] = 'install yum rpm-ostree'
+config_opts['chroot_setup_cmd'] = 'install yum /usr/bin/ostree rpm-ostree'
 config_opts['extra_chroot_dirs'] = ['/run/lock']
 config_opts['plugin_conf']['bind_mount_enable'] = True
 config_opts['plugin_conf']['bind_mount_opts']['dirs'].append(('${work_dir}', '${work_dir}'))


### PR DESCRIPTION
We need to explicitly require the commandline; rpm-ostree no longer
does since
https://mail.gnome.org/archives/ostree-list/2017-February/msg00010.html
=>
http://pkgs.fedoraproject.org/cgit/rpms/ostree.git/commit/?id=3b37a92bc97525bf1550935e8e26447e29466b6b