### PR TITLE
Log stderr statements as info if the process exited successfully.

### DIFF
--- a/fedmsg_atomic_composer/composer.py
+++ b/fedmsg_atomic_composer/composer.py
@@ -235,7 +235,7 @@ class AtomicComposer(object):
         if out:
             self.log.info(out)
         if err:
-            if p.returncode != 0:
+            if p.returncode == 0:
                 self.log.info(err)
             else:
                 self.log.error(err)


### PR DESCRIPTION
This commit fixes a bug where rpm-ostree output was being logged as
an error when rpm-ostree exited successfully, and was being logged
as info when it exited with an error code.

fixes #20

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>